### PR TITLE
Modify various functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/mirai_exporter.py
+++ b/mirai_exporter.py
@@ -686,7 +686,7 @@ class export_mirai(bpy.types.Operator):
                                         export_hierarchy_full_collections=False, 
                                         export_extra_animations=False, 
                                         filter_glob='*.glb',)
-            
+    
             self.report({'INFO'}, "Exported to " + bpy.context.scene.folder + file_name+".glb")
             return {'FINISHED'}
         else:

--- a/mirai_exporter.py
+++ b/mirai_exporter.py
@@ -155,6 +155,7 @@ def restoreView_and_save(self,context):
                         space.overlay.show_object_origins = True
                         space.overlay.show_outline_selected = True
                         space.shading.show_xray = False
+                        space.overlay.show_floor = True
         
         
     # Pack all resources
@@ -436,11 +437,12 @@ class OBJECT_PT_exporterMirai(bpy.types.Panel):
         longWf = layout.box()
         col2 = longWf.column()
         row = col2.row()
-        row.operator('opr.center_oporigins_operator', text='Apply modifiers')
+        row.operator('opr.initial_setup', text='Initial setup')
         row = col2.row()
         row.operator('opr.center_origins_operator', text='Center origins')
         row = col2.row()
-        row.operator('opr.initial_setup', text='Initial setup')
+        row.operator('opr.center_oporigins_operator', text='Apply modifiers')
+
 
         layout.label(text="General")
         boxSetup = layout.box()
@@ -966,8 +968,8 @@ class apply_mod(bpy.types.Operator):
     def execute(self, context):        # execute() is called when running the operator.
 
         # The original script
-        # obj = bpy.context.object
-        obj = bpy.context.active_object 
+        obj = bpy.context.object  #this plug in have to use this code to work
+        # obj = bpy.context.active_object  --> this plugin will not work with this
         #Hide all objects but the selected one
         for obj in bpy.data.objects:
             if obj != bpy.context.active_object:

--- a/mirai_exporter.py
+++ b/mirai_exporter.py
@@ -409,7 +409,7 @@ def create_measure_cube(self,context):
 
     
 PROPS = [
-    ("folder", bpy.props.StringProperty(name='',default=os.getcwd(),description="File path used by the file selector",maxlen=1024,subtype='FILE_PATH')),
+    ("folder", bpy.props.StringProperty(name='',default=bpy.path.abspath('//'),description="File path used by the file selector",maxlen=1024,subtype='FILE_PATH')),
     ("measure_cube",bpy.props.BoolProperty(name="Measure cube", default=False, description="Measure cube")),
 ]
 
@@ -483,6 +483,14 @@ class export_mirai(bpy.types.Operator):
     bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
+    # Get the path where the blend file is located
+        basedir = bpy.path.abspath('//')
+
+    # Get file name:
+        filename = bpy.path.basename(bpy.context.blend_data.filepath)
+
+    # Remove .blend extension:
+        filename = os.path.splitext(filename)[0]
         
         #PREVIOUS COMPROBATIONS -----------------
 
@@ -580,7 +588,7 @@ class export_mirai(bpy.types.Operator):
                 obj.select_set(True)
             bpy.data.collections["raycast"].objects[0].select_set(True)
 
-            bpy.ops.export_scene.gltf(  filepath= bpy.context.scene.folder +file_name+ ".glb",
+            bpy.ops.export_scene.gltf(  filepath=os.path.join(basedir+'Hotel_'+filename+'_rooms'),
                                         check_existing=False,
                                         # export_import_convert_lighting_mode='SPEC',
                                         # gltf_export_id='', 
@@ -743,7 +751,7 @@ class export_mirai(bpy.types.Operator):
                     for obj in bpy.data.collections["rooms"].objects:
                             obj.select_set(True)
 
-                    bpy.ops.export_scene.gltf(  filepath= bpy.context.scene.folder +file_name+ ".glb",
+                    bpy.ops.export_scene.gltf(  filepath=os.path.join(basedir+'Hotel_'+filename+'_rooms'),
                                                     check_existing=False,
                                                     # export_import_convert_lighting_mode='SPEC',
                                                     # gltf_export_id='', 

--- a/mirai_exporter.py
+++ b/mirai_exporter.py
@@ -22,16 +22,45 @@ def check_collections(self,context):
     if 'rooms' not in bpy.data.collections:
         bpy.data.collections.new('rooms')
         bpy.context.scene.collection.children.link(bpy.data.collections['rooms'])
-    
-    # Check if 'raycas_model' collection exists, if not create it
+
+    #create cube
+        bpy.ops.mesh.primitive_cube_add(size=2, enter_editmode=False, align='WORLD', location=(0, 0, 0), scale=(1, 1, 1))
+
+        obj = bpy.context.object
+
+        for obj in bpy.context.selected_objects:
+            obj.name = "Cube"
+
+    #link the cube to "rooms" collection
+            bpy.context.scene.collection.children.link(collection)
+    # our created cube is the active one
+        ob = bpy.context.active_object
+    # Remove object from all collections not used in a scene
+        bpy.ops.collection.objects_remove_all()
+    # add it to our rooms collection
+        bpy.data.collections['rooms'].objects.link(ob)
+        bpy.context.object.show_wire = True
+
+    # Check if 'raycast_model' collection exists, if not create it
     if 'raycast' not in bpy.data.collections:
         bpy.data.collections.new('raycast')
         bpy.context.scene.collection.children.link(bpy.data.collections['raycast'])
-   
-def is_collection_empty(self,conetext,name):
-    if name in bpy.data.collections:
-        if len(bpy.data.collections[name].objects) == 0:
-            return True
+    #create raycast cube
+        bpy.ops.mesh.primitive_cube_add(size=2, enter_editmode=False, align='WORLD', location=(0, 0, 0), scale=(1, 1, 1))
+    #link raycast cube to "raycast" collection
+        bpy.context.scene.collection.children.link(collection)
+    # our created cube is the active one
+        ob = bpy.context.active_object
+    # Remove object from all collections not used in a scene
+        bpy.ops.collection.objects_remove_all()
+    # add it to our raycast collection
+        bpy.data.collections['raycast'].objects.link(ob)
+        obj = bpy.context.object
+
+        for obj in bpy.context.selected_objects:
+            obj.name = "raycast"
+            
+        bpy.context.object.show_wire = True
     return False
 
 def raycast_screenshot(self,context):

--- a/mirai_exporter.py
+++ b/mirai_exporter.py
@@ -409,7 +409,7 @@ def create_measure_cube(self,context):
 
     
 PROPS = [
-    ("folder", bpy.props.StringProperty(name='',default=bpy.path.abspath('//'),description="File path used by the file selector",maxlen=1024,subtype='FILE_PATH')),
+    ("folder", bpy.props.StringProperty(name='',default="",description="File path used by the file selector",maxlen=1024,subtype='FILE_PATH')),
     ("measure_cube",bpy.props.BoolProperty(name="Measure cube", default=False, description="Measure cube")),
 ]
 

--- a/mirai_exporter.py
+++ b/mirai_exporter.py
@@ -22,45 +22,16 @@ def check_collections(self,context):
     if 'rooms' not in bpy.data.collections:
         bpy.data.collections.new('rooms')
         bpy.context.scene.collection.children.link(bpy.data.collections['rooms'])
-
-    #create cube
-        bpy.ops.mesh.primitive_cube_add(size=2, enter_editmode=False, align='WORLD', location=(0, 0, 0), scale=(1, 1, 1))
-
-        obj = bpy.context.object
-
-        for obj in bpy.context.selected_objects:
-            obj.name = "Cube"
-
-    #link the cube to "rooms" collection
-            bpy.context.scene.collection.children.link(collection)
-    # our created cube is the active one
-        ob = bpy.context.active_object
-    # Remove object from all collections not used in a scene
-        bpy.ops.collection.objects_remove_all()
-    # add it to our rooms collection
-        bpy.data.collections['rooms'].objects.link(ob)
-        bpy.context.object.show_wire = True
-
-    # Check if 'raycast_model' collection exists, if not create it
+    
+    # Check if 'raycas_model' collection exists, if not create it
     if 'raycast' not in bpy.data.collections:
         bpy.data.collections.new('raycast')
         bpy.context.scene.collection.children.link(bpy.data.collections['raycast'])
-    #create raycast cube
-        bpy.ops.mesh.primitive_cube_add(size=2, enter_editmode=False, align='WORLD', location=(0, 0, 0), scale=(1, 1, 1))
-    #link raycast cube to "raycast" collection
-        bpy.context.scene.collection.children.link(collection)
-    # our created cube is the active one
-        ob = bpy.context.active_object
-    # Remove object from all collections not used in a scene
-        bpy.ops.collection.objects_remove_all()
-    # add it to our raycast collection
-        bpy.data.collections['raycast'].objects.link(ob)
-        obj = bpy.context.object
-
-        for obj in bpy.context.selected_objects:
-            obj.name = "raycast"
-            
-        bpy.context.object.show_wire = True
+   
+def is_collection_empty(self,conetext,name):
+    if name in bpy.data.collections:
+        if len(bpy.data.collections[name].objects) == 0:
+            return True
     return False
 
 def raycast_screenshot(self,context):


### PR DESCRIPTION


- Allow exporting without raycast collection: some projects will not have raycast (exp: Camping Armanello 100377989) so I modified the code to allow taking screenshot and export without "raycast" collection

- Add new button "Initial Set up": clicking this button will create the collections and cubes, alongside their material, I want to set the material right at the start instead of when exporting so it's easier to work with. The default behaviour does not allow creating objects, only collection.

- Add "purge data" function alongside saving file: purging unused data helps reduce filesize when uploading

- Modify "opr.center_origins_operator": this operator isn't simply setting median origins, it calculates all the bounding box of all selected objects and move all the objects in scene accordingly.

- Set the default export path to be the same as blend file, it should appear empty but the glb will be exported to the same folder as the blend file.

